### PR TITLE
fix(#2): data-based stuck detection

### DIFF
--- a/src/lazycoder/executor.py
+++ b/src/lazycoder/executor.py
@@ -19,6 +19,7 @@ from github import Github
 from .budget import DailyBudget, add_entry, over_hard_limit
 from .config import Config
 from .models import RunResult, Task
+from .run_tracker import record_result
 
 
 def _build_prompt(issue_title: str, issue_body: str, task_text: str, prior_status: str | None) -> str:
@@ -165,6 +166,7 @@ def run_task(task: Task, budget: DailyBudget, cfg: Config) -> RunResult:
             comment_id = nc.id
 
         add_entry(budget, task.repo, task.issue_number, task.task_text, task.estimate_usd, actual_cost)
+        record_result(task.repo, task.issue_number, success=changed)
         return RunResult(task=task, success=changed, actual_cost=actual_cost,
                          branch=branch, notes=summary, status_comment_id=comment_id)
 
@@ -176,6 +178,7 @@ def run_task(task: Task, budget: DailyBudget, cfg: Config) -> RunResult:
             )
         except Exception:
             pass
+        record_result(task.repo, task.issue_number, success=False)
         return RunResult(task=task, success=False, actual_cost=0.0, branch=branch, notes=str(exc))
     finally:
         if repo_dir and repo_dir.exists():

--- a/src/lazycoder/planner.py
+++ b/src/lazycoder/planner.py
@@ -33,15 +33,12 @@ Cost estimates per subtask:
   medium ~$0.05  (feature, refactor, few files)
   large  ~$0.10  (complex, many files, unclear scope)
 
-Flag an issue as "stuck" if its status says the same thing for 2+ runs.
-
 Return a JSON array — one entry per issue:
 [
   {
     "issue": 42,
     "repo": "owner/repo",
-    "items": [{"text": "...", "estimate_usd": 0.05, "done": false}, ...],
-    "stuck": false
+    "items": [{"text": "...", "estimate_usd": 0.05, "done": false}, ...]
   }
 ]
 Only include issues that need a plan created or updated. Skip issues that already
@@ -179,10 +176,6 @@ def run_planner(
         else:
             c = issue.create_comment(body)
             plan.comment_id = c.id
-
-        if upd.get("stuck"):
-            issue.add_to_labels("needs-human")
-            print(f"[planner] #{upd['issue']} flagged as stuck → needs-human")
 
         plans.append(plan)
 

--- a/src/lazycoder/run_tracker.py
+++ b/src/lazycoder/run_tracker.py
@@ -1,0 +1,59 @@
+"""Track consecutive failed runs per issue in run_counts.json.
+
+Key: "owner/repo#42"
+Value: int — number of consecutive runs with no success=True result.
+Resets to 0 on any successful run for that issue.
+
+Used by the scheduler (pure Python) to flag issues as needs-human
+after STUCK_THRESHOLD consecutive failures — no LLM needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+RUN_COUNTS_FILE = Path("run_counts.json")
+STUCK_THRESHOLD = 3
+
+
+def _key(repo: str, issue: int) -> str:
+    return f"{repo}#{issue}"
+
+
+def load_counts(path: Path = RUN_COUNTS_FILE) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def save_counts(counts: dict[str, int], path: Path = RUN_COUNTS_FILE) -> None:
+    path.write_text(json.dumps(counts, indent=2))
+
+
+def record_result(repo: str, issue: int, success: bool, path: Path = RUN_COUNTS_FILE) -> int:
+    """Increment or reset the failure counter. Returns the new count."""
+    counts = load_counts(path)
+    k = _key(repo, issue)
+    if success:
+        counts[k] = 0
+    else:
+        counts[k] = counts.get(k, 0) + 1
+    save_counts(counts, path)
+    return counts[k]
+
+
+def is_stuck(repo: str, issue: int, path: Path = RUN_COUNTS_FILE) -> bool:
+    counts = load_counts(path)
+    return counts.get(_key(repo, issue), 0) >= STUCK_THRESHOLD
+
+
+def stuck_issues(path: Path = RUN_COUNTS_FILE) -> list[tuple[str, int, int]]:
+    """Return list of (repo, issue_number, fail_count) for stuck issues."""
+    counts = load_counts(path)
+    result = []
+    for k, count in counts.items():
+        if count >= STUCK_THRESHOLD:
+            repo, issue_str = k.rsplit("#", 1)
+            result.append((repo, int(issue_str), count))
+    return result

--- a/src/lazycoder/scheduler.py
+++ b/src/lazycoder/scheduler.py
@@ -13,6 +13,7 @@ from github import Github
 
 from .budget import DailyBudget, remaining_soft
 from .models import Plan, Priority, Task
+from .run_tracker import is_stuck
 
 
 # Priority label → sort key (lower = higher priority)
@@ -68,6 +69,15 @@ def schedule(
 
         if label_names & set(blocked_labels):
             print(f"[scheduler] #{plan.issue_number} skipped (blocked label)")
+            continue
+
+        # Data-based stuck detection — no LLM needed
+        if is_stuck(plan.repo, plan.issue_number):
+            print(f"[scheduler] #{plan.issue_number} stuck ({3}+ failed runs) → adding needs-human")
+            try:
+                issue.add_to_labels("needs-human")
+            except Exception:
+                pass
             continue
 
         sort_key = _priority_of(label_names)


### PR DESCRIPTION
Closes #2

**New module:** `run_tracker.py` — tracks consecutive failed runs per issue in `run_counts.json`
- `record_result(repo, issue, success)` — increments or resets counter
- `is_stuck(repo, issue)` — returns True after 3+ consecutive failures
- `stuck_issues()` — list all stuck issues for reporting

**Scheduler:** checks `is_stuck()` before adding candidates — applies `needs-human` label and skips. Pure Python, no LLM.

**Executor:** calls `record_result()` after every task (success or failure/exception).

**Planner:** removed stuck-detection from LLM prompt entirely. Saves tokens every run.