### PR TITLE
fix(#1): post summaries to dedicated run log issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config.yaml
 spent_today.json
+run_counts.json
 run_log.json
 *.json
 __pycache__/

--- a/src/lazycoder/run_log.py
+++ b/src/lazycoder/run_log.py
@@ -1,0 +1,74 @@
+"""Manage the dedicated lazycoder run log issue.
+
+On first run, creates a pinned issue titled '[lazycoder] Run log' in each repo
+and stores its number in run_log.json. All ## Summary comments go there.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from github import Github
+from github.Repository import Repository
+
+RUN_LOG_FILE = Path("run_log.json")
+RUN_LOG_TITLE = "[lazycoder] Run log"
+RUN_LOG_LABEL = "bot-meta"
+RUN_LOG_BODY = (
+    "This issue is the lazycoder run log. "
+    "Each automated run posts a `## Summary` comment here.\n\n"
+    "Do not close this issue."
+)
+
+
+def _load() -> dict[str, int]:
+    if not RUN_LOG_FILE.exists():
+        return {}
+    return json.loads(RUN_LOG_FILE.read_text())
+
+
+def _save(data: dict[str, int]) -> None:
+    RUN_LOG_FILE.write_text(json.dumps(data, indent=2))
+
+
+def _ensure_label(repo: Repository) -> None:
+    existing = {lbl.name for lbl in repo.get_labels()}
+    if RUN_LOG_LABEL not in existing:
+        repo.create_label(name=RUN_LOG_LABEL, color="0075ca", description="lazycoder internal")
+
+
+def get_or_create_log_issue(repo_name: str, token: str) -> int:
+    """Return the issue number of the run log issue, creating it if needed."""
+    data = _load()
+    if repo_name in data:
+        return data[repo_name]
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+    _ensure_label(repo)
+
+    # Check if it already exists (e.g. run_log.json was deleted)
+    for issue in repo.get_issues(state="open", labels=[RUN_LOG_LABEL]):
+        if issue.title == RUN_LOG_TITLE:
+            data[repo_name] = issue.number
+            _save(data)
+            return issue.number
+
+    issue = repo.create_issue(
+        title=RUN_LOG_TITLE,
+        body=RUN_LOG_BODY,
+        labels=[RUN_LOG_LABEL],
+    )
+    # Pin if API supports it (requires admin — silently ignore if not)
+    try:
+        repo._requester.requestJsonAndCheck(
+            "PUT", f"{repo.url}/issues/{issue.number}/pin"
+        )
+    except Exception:
+        pass
+
+    print(f"[run_log] Created run log issue #{issue.number} in {repo_name}")
+    data[repo_name] = issue.number
+    _save(data)
+    return issue.number

--- a/src/lazycoder/summarizer.py
+++ b/src/lazycoder/summarizer.py
@@ -51,8 +51,9 @@ def write_summary(results: list[RunResult], model: str, token: str, bot_username
 
 
 def post_summary(results: list[RunResult], model: str, token: str, bot_username: str, repos: list[str]) -> None:
-    """Post ## Summary as a comment on the first open issue of each repo."""
+    """Post ## Summary as a comment on the dedicated run log issue for each repo."""
     from github import Github
+    from .run_log import get_or_create_log_issue
     gh = Github(token)
 
     by_repo: dict[str, list[RunResult]] = {}
@@ -67,18 +68,9 @@ def post_summary(results: list[RunResult], model: str, token: str, bot_username:
         summary_text = write_summary(repo_results, model, token, bot_username)
         body = f"## Summary\n{summary_text}"
 
+        issue_number = get_or_create_log_issue(repo_name, token)
         repo = gh.get_repo(repo_name)
-        issues = list(repo.get_issues(state="open"))
-        if not issues:
-            continue
+        issue = repo.get_issue(issue_number)
 
-        # Upsert on the first issue
-        issue = issues[0]
-        for c in issue.get_comments():
-            if c.user.login == bot_username and c.body.startswith("## Summary"):
-                c.edit(body)
-                print(f"[summarizer] Updated summary on {repo_name}#{issue.number}")
-                break
-        else:
-            issue.create_comment(body)
-            print(f"[summarizer] Posted summary on {repo_name}#{issue.number}")
+        issue.create_comment(body)
+        print(f"[summarizer] Posted summary on {repo_name}#{issue_number}")


### PR DESCRIPTION
## Summary
- Creates a dedicated `[lazycoder] Run log` pinned issue per repo on first run
- Stores issue number in `run_log.json` (gitignored) to avoid repeated lookups
- Summarizer now appends `## Summary` comments to the log issue instead of the first open issue

Closes #1

## Test plan
- [ ] Run `lazycoder run` — summary posts to `[lazycoder] Run log` issue, not first open issue
- [ ] Delete `run_log.json`, run again — issue is rediscovered and re-cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)